### PR TITLE
ENH: Implement pre commit in project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
+    hooks:
+    -   id: mypy
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.5.2
+    hooks:
+      - id: isort

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+_install_dev:
+	pip install -r test-requirements.txt
+	pre-commit install
+
+_install_prod:
+	pip install -r requirements.txt
+
+_mypy:
+	@mypy botcity/
+
+_flake8:
+	@flake8 --show-source botcity/
+
+_isort-fix:
+	@isort botcity/
+
+_isort:
+	@isort --diff --check-only botcity/
+
+lint: _flake8 _mypy _isort
+format-code: _isort-fix ## Format code
+dev: _install_prod _install_dev
+prod: _install_prod

--- a/botcity/maestro/__init__.py
+++ b/botcity/maestro/__init__.py
@@ -1,6 +1,7 @@
+from botcity.maestro._version import get_versions
+
 from .model import *  # noqa: F401, F403
 from .sdk import BotMaestroSDK  # noqa: F401, F403
 
-from botcity.maestro._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
 pytest
 mypy
 flake8
+isort
+pre-commit


### PR DESCRIPTION
Implementation of pre-commit to standardize the project whenever possible, using four hooks:

- check-YAML (Checking the YAML files of the project)
- mypy (Check types in python files)
- flake8 (Checks if the pep8 standard is being followed)
- isort (formats the code to pep8)

And to help, a Makefile was created so that the installation and execution of linters are faster and more practical.