### PR TITLE
FIX: Passing the timeout value downstream to the implementation.

### DIFF
--- a/botcity/maestro/datapool/datapool.py
+++ b/botcity/maestro/datapool/datapool.py
@@ -105,7 +105,7 @@ class DataPool:
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}'
 
         with requests.post(url, data=json.dumps(data), headers=self.maestro._headers(),
-                           timeout=self.maestro.timeout) as req:
+                           timeout=self.maestro._timeout) as req:
             if req.ok:
                 self._update_from_json(payload=req.content)
                 return True
@@ -121,7 +121,7 @@ class DataPool:
         data = self.to_dict()
         data['active'] = False
         with requests.post(url, data=json.dumps(data), headers=self.maestro._headers(),
-                           timeout=self.maestro.timeout) as req:
+                           timeout=self.maestro._timeout) as req:
             if req.ok:
                 self._update_from_json(payload=req.content)
                 return True
@@ -135,7 +135,7 @@ class DataPool:
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}'
 
-        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             if req.ok:
                 self._update_from_json(payload=req.content)
                 return self.active
@@ -149,7 +149,7 @@ class DataPool:
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}/summary'
 
-        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             if req.ok:
                 return json.loads(req.content)
             req.raise_for_status()
@@ -168,7 +168,7 @@ class DataPool:
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}/push'
 
         with requests.post(url, data=entry.to_json(), headers=self.maestro._headers(),
-                           timeout=self.maestro.timeout) as req:
+                           timeout=self.maestro._timeout) as req:
             if req.ok:
                 entry.update_from_json(payload=req.content)
                 return entry
@@ -184,7 +184,7 @@ class DataPool:
             DataPoolEntry: The entry that was fetched.
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}/entry/{entry_id}'
-        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             if req.ok:
                 entry = DataPoolEntry()
                 entry.update_from_json(payload=req.content)
@@ -222,7 +222,7 @@ class DataPool:
 
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}/pull'
-        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.get(url, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             if req.status_code == 204:
                 return None
 
@@ -240,5 +240,5 @@ class DataPool:
         Delete DataPool in Maestro.
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.label}'
-        with requests.delete(url, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.delete(url, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             req.raise_for_status()

--- a/botcity/maestro/datapool/entry.py
+++ b/botcity/maestro/datapool/entry.py
@@ -133,7 +133,7 @@ class DataPoolEntry:
         """
         url = f'{self.maestro.server}/api/v2/datapool/{self.datapool_label}/entry/{self.entry_id}'
         data = self.json_to_update()
-        with requests.post(url, data=data, headers=self.maestro._headers(), timeout=self.maestro.timeout) as req:
+        with requests.post(url, data=data, headers=self.maestro._headers(), timeout=self.maestro._timeout) as req:
             if req.ok:
                 return self.update_from_json(req.content)
             req.raise_for_status()

--- a/botcity/maestro/impl/interface.py
+++ b/botcity/maestro/impl/interface.py
@@ -141,7 +141,7 @@ class BotMaestroSDKInterface:
         self._task_id = 0
         self._impl: BotMaestroSDKInterface = None  # type: ignore
         self._version = None
-        self.timeout = 30.0
+        self._timeout = 30.0
 
         self.server = server
 

--- a/botcity/maestro/impl/v2.py
+++ b/botcity/maestro/impl/v2.py
@@ -63,7 +63,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         data = {"login": self._sdk.organization, "key": self._sdk._key}
         headers = {'Content-Type': 'application/json'}
 
-        with requests.post(url, data=json.dumps(data), headers=headers, timeout=self.timeout) as req:
+        with requests.post(url, data=json.dumps(data), headers=headers, timeout=self._timeout) as req:
             if req.ok:
                 self.access_token = req.json()['accessToken']
             else:
@@ -87,7 +87,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         data = {"taskId": task_id, "title": title,
                 "message": message, "type": alert_type}
 
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -117,7 +117,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
 
         data = {"emails": email, "logins": users, "subject": subject, "body": body,
                 "type": msg_type, "group": group}
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.status_code != 200:
                 raise ValueError(
                     'Error during message. Server returned %d. %s' %
@@ -154,7 +154,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
             data["minExecutionDate"] = min_execution_date.isoformat()
 
         headers = self._headers()
-        with requests.post(url, json=data, headers=headers, timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=headers, timeout=self._timeout) as req:
             if req.ok:
                 return model.AutomationTask.from_json(req.text)
             else:
@@ -183,7 +183,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         data = {"finishStatus": status, "finishMessage": message,
                 "state": "FINISHED"}
         headers = self._headers()
-        with requests.post(url, json=data, headers=headers, timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=headers, timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -207,7 +207,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         url = f'{self._sdk._server}/api/v2/task/{task_id}'
         data = {"state": "START"}
         headers = self._headers()
-        with requests.post(url, json=data, headers=headers, timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=headers, timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -230,7 +230,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/task/{task_id}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 payload = req.text
                 return model.AutomationTask.from_json(payload)
@@ -255,7 +255,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         url = f'{self._sdk._server}/api/v2/task/{task_id}'
         data = {"interrupted": True}
         headers = self._headers()
-        with requests.post(url, json=data, headers=headers, timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=headers, timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -282,7 +282,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         cols = [asdict(c) for c in columns]
 
         data = {"activityLabel": activity_label, "columns": cols, 'organizationLabel': self._sdk.organization}
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -306,7 +306,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/log/{activity_label}/entry'
 
-        with requests.post(url, json=values, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=values, headers=self._headers(), timeout=self._timeout) as req:
             if req.status_code != 200:
                 try:
                     message = 'Error during new log entry. Server returned %d. %s' % (
@@ -335,7 +335,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         if date:
             days = (datetime.datetime.now()-datetime.datetime.strptime(date, "%d/%m/%Y")).days + 1
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 log = req.json()
                 columns = log.get('columns')
@@ -345,7 +345,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
                 url = f'{self._sdk._server}/api/v2/log/{activity_label}/entry-list'
 
                 data = {"days": days}
-                with requests.get(url, params=data, headers=self._headers(), timeout=self.timeout) as entry_req:
+                with requests.get(url, params=data, headers=self._headers(), timeout=self._timeout) as entry_req:
                     if entry_req.ok:
                         log_data = []
                         for en in entry_req.json():
@@ -386,7 +386,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         # date em branco eh tudo
         url = f'{self._sdk._server}/api/v2/log/{activity_label}'
 
-        with requests.delete(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.delete(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.status_code != 200:
                 try:
                     message = 'Error during log delete. Server returned %d. %s' % (
@@ -417,7 +417,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
                 fields={'file': (artifact_name, f)}
             )
             headers = {**self._headers(), 'Content-Type': data.content_type}
-            with requests.post(url, data=data, headers=headers, timeout=self.timeout) as req:
+            with requests.post(url, data=data, headers=headers, timeout=self._timeout) as req:
                 if req.ok:
                     return artifact_id
                 else:
@@ -443,7 +443,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/artifact'
         data = {'taskId': task_id, 'name': name, 'filename': filename}
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -463,13 +463,13 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/artifact?size=5&page=0&sort=dateCreation,desc&days={days}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 content = req.json()['content']
                 response = [model.Artifact.from_dict(a) for a in content]
                 for page in range(1, req.json()['totalPages']):
                     url = f'{self._sdk._server}/api/v2/artifact?size=5&page={page}&sort=dateCreation,desc&days={days}'
-                    with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+                    with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
                         content = req.json()['content']
                         response.extend([model.Artifact.from_dict(a) for a in content])
                 return response
@@ -493,13 +493,13 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/artifact/{artifact_id}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 payload = req.json()
                 filename = payload['fileName']
 
                 url = f'{self.server}/api/v2/artifact/{artifact_id}/file'
-                with requests.get(url, headers=self._headers(), timeout=self.timeout) as req_file:
+                with requests.get(url, headers=self._headers(), timeout=self._timeout) as req_file:
                     file_content = req_file.content
 
                 return filename, file_content
@@ -542,7 +542,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
                 'stackTrace': trace, 'language': 'PYTHON', 'tags': tags}
 
         response = None
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.status_code == 201:
                 response = req.json()
             else:
@@ -623,7 +623,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
             headers = self._headers()
             headers['Content-Type'] = data_screenshot.content_type
 
-            with requests.post(url_screenshot, data=data_screenshot, headers=headers, timeout=self.timeout) as req:
+            with requests.post(url_screenshot, data=data_screenshot, headers=headers, timeout=self._timeout) as req:
                 if not req.ok:
                     try:
                         message = 'Error during new log entry. Server returned %d. %s' % (
@@ -649,7 +649,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         )
         headers = self._headers()
         headers['Content-Type'] = file.content_type
-        with requests.post(url_attachments, data=file, headers=headers, timeout=self.timeout) as req:
+        with requests.post(url_attachments, data=file, headers=headers, timeout=self._timeout) as req:
             if not req.ok:
                 try:
                     message = 'Error during new log entry. Server returned %d. %s' % (
@@ -671,7 +671,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/credential/{label}/key/{key}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return str(req.text)
             else:
@@ -703,7 +703,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
             'value': value
         }
         url = f'{self._sdk._server}/api/v2/credential/{label}/key'
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if not req.ok:
                 req.raise_for_status()
 
@@ -717,7 +717,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/credential/{label}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -732,7 +732,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         }
         url = f'{self._sdk._server}/api/v2/credential'
 
-        with requests.post(url, json=data, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.post(url, json=data, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return model.ServerMessage.from_json(req.text)
             else:
@@ -751,7 +751,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         url = f'{self._sdk.server}/api/v2/datapool'
         pool.maestro = self
         with requests.post(url, data=json.dumps(pool.to_dict()), headers=self._headers(),
-                           timeout=self.timeout) as req:
+                           timeout=self._timeout) as req:
             if req.ok:
                 return pool
             req.raise_for_status()
@@ -768,7 +768,7 @@ class BotMaestroSDKV2(BotMaestroSDKInterface):
         """
         url = f'{self._sdk._server}/api/v2/datapool/{label}'
 
-        with requests.get(url, headers=self._headers(), timeout=self.timeout) as req:
+        with requests.get(url, headers=self._headers(), timeout=self._timeout) as req:
             if req.ok:
                 return DataPool.from_json(payload=req.content, maestro=self)
             req.raise_for_status()

--- a/botcity/maestro/sdk.py
+++ b/botcity/maestro/sdk.py
@@ -50,8 +50,19 @@ class BotMaestroSDK(BotMaestroSDKInterface):
                 raise ex
             self._impl = v2.BotMaestroSDKV2(self.server, self._login, self._key, sdk=self)
             self._version = "999.0.0"
+            self._impl._timeout = self.timeout
             self._impl.access_token = self.access_token
             self._impl._login = self._login
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self._timeout = value
+        if self._impl:
+            self._impl._timeout = value
 
     def login(self, server: Optional[str] = None, login: Optional[str] = None, key: Optional[str] = None):
         """


### PR DESCRIPTION
This is a temporary fix as we will remove the impl v1 and move back to having simply the SDK with the latest SDK since there are no longer V1 maestro instances.

Tests are passing locally:
![image](https://github.com/botcity-dev/botcity-maestro-sdk-python/assets/8185425/70e9dbd3-4a6d-41a2-a947-7d9bdce78a30)
