### PR TITLE
ENH: Add is_online property to easily determine whether we are online or not

### DIFF
--- a/botcity/maestro/sdk.py
+++ b/botcity/maestro/sdk.py
@@ -240,11 +240,17 @@ class BotMaestroSDK:
 
     @property
     def timeout(self):
+        """The timeout for the requests"""
         return self._timeout
 
     @timeout.setter
     def timeout(self, value):
         self._timeout = value
+
+    @property
+    def is_online(self):
+        """Whether or not the object is connected to the BotCity Orchestrator portal"""
+        return self.access_token is not None and self.access_token != ""
 
     def login(self, server: Optional[str] = None, login: Optional[str] = None, key: Optional[str] = None):
         """

--- a/tests/integration/test_login.py
+++ b/tests/integration/test_login.py
@@ -39,3 +39,4 @@ def test_login_error_in_key_none(maestro_test_to_login: BotMaestroSDK):
 def test_login_success(maestro_test_to_login: BotMaestroSDK):
     maestro_test_to_login.login(server=conftest.SERVER, login=conftest.LOGIN, key=conftest.KEY)
     assert maestro_test_to_login.access_token
+    assert maestro_test_to_login.is_online


### PR DESCRIPTION
Closes #35 

```python
In [1]: from botcity.maestro import *

In [2]: maestro = BotMaestroSDK()

In [3]: maestro.is_online
Out[3]: False

In [4]: import os

In [5]: SERVER = os.getenv("BOTCITY_SERVER")

In [6]: LOGIN = os.getenv("BOTCITY_LOGIN")

In [7]: KEY = os.getenv("BOTCITY_KEY")

In [8]: maestro.login(server=SERVER, login=LOGIN, key=KEY)

In [9]: maestro.is_online
Out[9]: True
```

Attn. @morgannadev 